### PR TITLE
cpu multiplies the values and sends to periph

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git@github.com:behzadjoudat/iob-lib.git
 [submodule "submodules/RIFFA"]
 	path = submodules/RIFFA
-	url = git@github.com:behzadjoudat/riffa.git
+	url = git@github.com:IObundle/riffa.git

--- a/hardware/hardware.mk
+++ b/hardware/hardware.mk
@@ -17,8 +17,10 @@ VHDR+=$(wildcard $(PCIE_INC_DIR)/*.vh)
 VHDR+=iob_pcie_swreg_gen.vh iob_pcie_swreg_def.vh
 VHDR+=$(LIB_DIR)/hardware/include/iob_lib.vh $(LIB_DIR)/hardware/include/iob_s_if.vh $(LIB_DIR)/hardware/include/iob_gen_if.vh 
 
+ifneq ($(SIMULATOR),verilator)
 INCLUDE+=$(RIFFA_DIR)/fpga/riffa_hdl
 INCLUDE+=$(RIFFA_DIR)/fpga/altera/de5/riffa_wrapper_de5.v
+endif
 
 #hardware include dirs
 INCLUDE+=$(incdir). $(incdir)$(PCIE_INC_DIR) $(incdir)$(LIB_DIR)/hardware/include

--- a/hardware/src/iob_pcie.v
+++ b/hardware/src/iob_pcie.v
@@ -41,7 +41,6 @@ module iob_pcie
 
 `include "iob_pcie_swreg_gen.vh"
    
-   
    `IOB_WIRE(PCIE_TX_DATA, DATA_W)
    iob_reg #(.DATA_W(32))
    pcie_tx_data (
@@ -52,19 +51,10 @@ module iob_pcie
 		 .data_in    (PCIE_TX_DATA_wdata),
 		 .data_out   (PCIE_TX_DATA)
 		 );
-   
-   
-   
-   reg [C_PCI_DATA_WIDTH-1:0] rData={C_PCI_DATA_WIDTH{1'b0}};
-   reg [C_PCI_DATA_WIDTH-1:0] tData={C_PCI_DATA_WIDTH{1'b0}};
-   reg [DATA_W-1:0] 		      rLen;
-   reg [DATA_W-1:0] 		      rCount;
-   reg [1:0] 		      rState,rState_nxt;
-   
+
    assign PCIE_CHNL_RX_CLK = PCIE_CLK;
    assign PCIE_CHNL_RX_ACK = (rState == 2'd1);
    assign PCIE_CHNL_RX_DATA_REN = (rState == 2'd1);
-   
    assign PCIE_CHNL_TX_CLK = PCIE_CLK;
    assign PCIE_CHNL_TX = (rState == 2'd3);
    assign PCIE_CHNL_TX_LAST = 1'd1;
@@ -72,12 +62,10 @@ module iob_pcie
    assign PCIE_CHNL_TX_OFF = 0;
    assign PCIE_CHNL_TX_DATA = tData;
    assign PCIE_CHNL_TX_DATA_VALID = (rState == 2'd3);
-   assign PCIE_RX_DATA_rdata = PCIE_CHNL_RX_DATA;
-   assign PCIE_RX_DATA1_rdata = PCIE_CHNL_RX_LEN;
+   assign PCIE_RX_DATA1_rdata =THENUMBER1 ; 
+   assign PCIE_RX_DATA_rdata = THENUMBER;
 
-   localparam WAIT=0, RX_DEFAULT=1,TX_EN=2, TX_FULL=3;
-   reg [DATA_W-1:0] the_result =  0;   
-
+   `IOB_VAR(rState_nxt, 2)
    iob_reg
      #(
        .DATA_W(2),
@@ -92,56 +80,164 @@ module iob_pcie
       .data_in (rState_nxt),
       .data_out (rState)
       );
-   
+
+   `IOB_VAR(rData_nxt, C_PCI_DATA_WIDTH)
+   iob_reg
+     #(
+       .DATA_W(C_PCI_DATA_WIDTH),
+       .RST_VAL(0)
+       )
+   pcie_rdata_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (rData_nxt),
+      .data_out (rData)
+      );
+
+   `IOB_WIRE(tData, C_PCI_DATA_WIDTH)
+   `IOB_VAR(tData_nxt, C_PCI_DATA_WIDTH)
+   iob_reg
+     #(
+       .DATA_W(C_PCI_DATA_WIDTH),
+       .RST_VAL(0)
+       )
+   pcie_tdata_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (tData_nxt),
+      .data_out (tData)
+      );
+
+   `IOB_VAR(rLen_nxt, DATA_W)
+   iob_reg
+     #(
+       .DATA_W(DATA_W),
+       .RST_VAL(0)
+       )
+   pcie_rlen_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (rLen_nxt),
+      .data_out (rLen)
+      );
+
+   `IOB_VAR(rCount_nxt, DATA_W)
+   iob_reg
+     #(
+       .DATA_W(DATA_W),
+       .RST_VAL(0)
+       )
+   pcie_rcount_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (rCount_nxt),
+      .data_out (rCount)
+      );
+
+   `IOB_WIRE(the_result, DATA_W)
+   `IOB_VAR(the_result_nxt, DATA_W)
+   iob_reg
+     #(
+       .DATA_W(DATA_W),
+       .RST_VAL(0)
+       )
+   pcie_theresult_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (the_result_nxt),
+      .data_out (the_result)
+      );
+
+   `IOB_WIRE(THENUMBER, DATA_W)
+   `IOB_VAR(THENUMBER_NXT, DATA_W)
+   iob_reg
+     #(
+       .DATA_W(DATA_W),
+       .RST_VAL(0)
+       )
+   pcie_thenumber_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (THENUMBER_NXT),
+      .data_out (THENUMBER)
+      );
+
+
+   `IOB_WIRE(THENUMBER1, DATA_W)
+   `IOB_VAR(THENUMBER1_NXT, DATA_W)
+   iob_reg
+     #(
+       .DATA_W(DATA_W),
+       .RST_VAL(0)
+       )
+   pcie_thenumber1_reg
+     (
+      .clk  (PCIE_CLK),
+      .arst (PCIE_RST),
+      .rst  (1'b0),
+      .en   (1'b1),
+      .data_in (THENUMBER1_NXT),
+      .data_out (THENUMBER1)
+      );
+
    `IOB_COMB begin
       if (PCIE_RST) begin
-	 rLen =  0;
-	 rCount =  0;
-	 rData =  0;
+	 rLen_nxt =  0;
+	 rCount_nxt =  0;
+	 rData_nxt =  0;
       end
-      else begin
-	 rState_nxt =  WAIT;
-	 case (rState)
-	   
-	   WAIT: begin // Wait for start of RX, save length
-	      if (PCIE_CHNL_RX) begin
-		 rLen =  PCIE_CHNL_RX_LEN;
-		 rCount =  0;
-		 rState_nxt =  RX_DEFAULT;
-	      end
+      case (rState)
+	2'd0: begin // Wait for start of RX, save length
+	   if (PCIE_CHNL_RX) begin
+	      rLen_nxt =  PCIE_CHNL_RX_LEN;
+	      THENUMBER1_NXT =  PCIE_CHNL_RX_LEN;
+	      rCount_nxt =  0;
+	      rState_nxt =  2'd1;
 	   end
-	   
-	   RX_DEFAULT: begin // Wait for last data in RX, save value
-	      if (PCIE_CHNL_RX_DATA_VALID) begin
-		 rData =  PCIE_CHNL_RX_DATA;
-		 rCount =  rCount + (C_PCI_DATA_WIDTH/DATA_W);
-	      end
+	end
+	2'd1: begin // Wait for last data in RX, save value
+	   if (PCIE_CHNL_RX_DATA_VALID) begin
+	      rData_nxt =  PCIE_CHNL_RX_DATA;
+	      THENUMBER_NXT = PCIE_CHNL_RX_DATA;
+	      rCount_nxt =  rCount + (C_PCI_DATA_WIDTH/DATA_W);
+	   end
+	   if (rCount >= rLen)
+	     rState_nxt =  2'd2;
+	end
+	2'd2: begin // Prepare for TX
+	   rCount_nxt =  (C_PCI_DATA_WIDTH/DATA_W);
+	   the_result_nxt = PCIE_TX_DATA;
+	   rLen_nxt = PCIE_TX_DATA;
+	   rState_nxt =  2'd3;
+	end
+	2'd3: begin // Start TX with save length and data value
+	   if (PCIE_CHNL_TX_DATA_REN & PCIE_CHNL_TX_DATA_VALID) begin
+	      tData_nxt =  {the_result - 1 , the_result } ;
+	      the_result_nxt = the_result-2;
+	      rCount_nxt =  rCount + (C_PCI_DATA_WIDTH/DATA_W);
 	      if (rCount >= rLen)
-		rState_nxt =  TX_EN;
+		rState_nxt =  2'd0;
 	   end
-	   
-	   TX_EN: begin // Prepare for TX
-	      rCount =  (C_PCI_DATA_WIDTH/DATA_W);
-	      rState_nxt =  TX_FULL;
-	      the_result = PCIE_TX_DATA;
-	      rLen = PCIE_TX_DATA;
-	   end
-	   
-	   TX_FULL: begin // Start TX with save length and data value
-	      if (PCIE_CHNL_TX_DATA_REN & PCIE_CHNL_TX_DATA_VALID) begin
-		 tData =  {the_result - 1 , the_result } ;
-		 the_result = the_result-2;
-		 rCount =  rCount + (C_PCI_DATA_WIDTH/DATA_W);
-		 if (rCount >= rLen)
-		   rState_nxt =  WAIT;
-	      end
-	   end
-	 endcase // case (rState)
-      end // else: !if(PCIE_RST)
+	end
+      endcase // case (rState)
    end // UNMATCHED !!
    
-   
-      
-      
-      
 endmodule // iob_pcie

--- a/mkregs.conf
+++ b/mkregs.conf
@@ -1,4 +1,5 @@
 //START_SWREG_TABLE pcie
 IOB_SWREG_W(PCIE_TX_DATA, 4, 0, -1, 0) //TO TEST value sent
 IOB_SWREG_R(PCIE_RX_DATA, 4, 0, -1, 0) //TO TEST value GET
+IOB_SWREG_R(PCIE_RX_DATA1, 4, 0, -1, 0) //TO TEST value GET
 


### PR DESCRIPTION
cpu multiplies the the number that has been recieved from the pcie and riffa then sends it back to the peripheral and then when the riffa c code is initialized to get the results the results from the multiplied number is sent one by one subtracting it to the pcie and riffa